### PR TITLE
minor changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11-alpine
+FROM golang:1.14-alpine
 
 RUN apk add git
 RUN go get -d -v github.com/mmcdole/gofeed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM golang:1.14-alpine
+#
+# build stage
+#
+FROM golang:1.14-alpine AS builder
 
 RUN apk add git
 RUN go get -d -v github.com/mmcdole/gofeed
@@ -6,12 +9,21 @@ RUN go get -d -v github.com/mmcdole/gofeed
 COPY . /go/src/app
 WORKDIR /go/src/app
 ARG release
-RUN go build -o main -ldflags "-X main.Version=${release:-$(git describe --abbrev=0 --tags)-$(git rev-list -1 --abbrev-commit HEAD)}" .
+RUN go build -o main -ldflags "-s -w -X main.Version=${release:-$(git describe --abbrev=0 --tags)-$(git rev-list -1 --abbrev-commit HEAD)}" .
 
+#
+# runtime image
+#
+FROM alpine:latest AS runtime
 
-FROM alpine:latest
+RUN apk add --no-cache ca-certificates
+
 WORKDIR /app
-COPY --from=0 /go/src/app/main .
-COPY config.json /app/config.json
+
+COPY --from=builder /go/src/app/main .
+COPY config.json ./config.json
+
+EXPOSE 9090
+
 ENTRYPOINT ["/app/main"]
 CMD ["--config", "/app/config.json"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '3.3'
 services:
-  xkcd:
+  app:
     build: .
     deploy:
       restart_policy:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/BuJo/mattermost-rss-reader
 
-go 1.12
+go 1.14
 
 require (
 	github.com/PuerkitoBio/goquery v1.5.0 // indirect

--- a/main.go
+++ b/main.go
@@ -88,7 +88,7 @@ var Version = "development"
 
 func main() {
 	cPath := flag.String("config", "./config.json", "Path to the config file.")
-	httpBind := flag.String("bind", "127.0.0.1:9090", "HTTP Binding")
+	httpBind := flag.String("bind", "", "HTTP Binding")
 	printVersion := flag.Bool("version", false, "Show Version")
 
 	flag.Parse()
@@ -101,14 +101,16 @@ func main() {
 	cfg := LoadConfig(*cPath)
 
 	// Set up command server
-	go func() {
-		http.HandleFunc("/feeds", feedCommandHandler(cfg))
-		fmt.Printf("Listening for commands on http://%s/feeds\n", *httpBind)
-		err := http.ListenAndServe(*httpBind, nil)
-		if err != nil {
-			fmt.Println("Error starting server:", err)
-		}
-	}()
+	if *httpBind != "" {
+		go func() {
+			http.HandleFunc("/feeds", feedCommandHandler(cfg))
+			fmt.Printf("Listening for commands on http://%s/feeds\n", *httpBind)
+			err := http.ListenAndServe(*httpBind, nil)
+			if err != nil {
+				fmt.Println("Error starting server:", err)
+			}
+		}()
+	}
 
 	//get all of our feeds and process them initially
 	subscriptions := make([]Subscription, 0)

--- a/main.go
+++ b/main.go
@@ -142,7 +142,7 @@ func run(cfg *Config, subscriptions []Subscription, ch chan<- FeedItem) {
 	for _, subscription := range subscriptions {
 		updates := subscription.getUpdates()
 		for _, update := range updates {
-			hsh := sha1.Sum(append([]byte(update.Title), []byte(subscription.config.URL)...))
+			hsh := sha1.Sum([]byte(update.GUID))
 
 			shownFeeds[hsh] = true
 
@@ -296,11 +296,16 @@ func itemToSimpleMessage(config *Config, item FeedItem) MattermostMessage {
 
 // itemToDetailedMessage formats a feed to be able to present it in Mattermost.
 func itemToDetailedMessage(config *Config, item FeedItem) MattermostMessage {
+        text := item.Description
+        if text == "" {
+          text = item.Content
+        }
+
 	attachment := MattermostAttachment{
 		Fallback:  config.sanitizer.Sanitize(item.Title),
 		Title:     config.sanitizer.Sanitize(item.Title),
 		TitleLink: item.Link,
-		Text:      config.sanitizer.Sanitize(item.Description),
+		Text:      config.sanitizer.Sanitize(text),
 	}
 
 	if item.Author != nil {
@@ -457,7 +462,7 @@ func (s Subscription) getUpdates() []gofeed.Item {
 	}
 
 	for _, i := range feed.Items {
-		if i.PublishedParsed != nil {
+		if i.GUID != "" {
 			updates = append(updates, *i)
 		}
 	}


### PR DESCRIPTION
First of all, thanks for your effort to provide RSS/Atom support for Mattermost.

In my use case I made some minor changes which you and others might find useful:
- use GUID as identifier for map "shownFeeds" instead of title+rss url
- use GUID to determine valid feed items instead of "publishedParsed"
- bump go from 1.11 to 1.14

Using GUID makes more sense since it should be unique in a feed. Furthermore, it is more likely to have GUID field in RSS/Atom than published date. I am aware this could be not be case in your setup.